### PR TITLE
feat: Show package version in Settings bundle titles

### DIFF
--- a/Sources/SwiftPackageList/Package.swift
+++ b/Sources/SwiftPackageList/Package.swift
@@ -70,6 +70,12 @@ extension Package {
     public var hasLicense: Bool {
         return license != nil
     }
+
+    /// The name of the package concatenated with version if available.
+    public var nameWithVersion: String {
+        guard let version else { return name }
+        return "\(name) (\(version))"
+    }
 }
 
 // MARK: - Deprecations

--- a/Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator.swift
+++ b/Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator.swift
@@ -50,7 +50,7 @@ struct SettingsBundleGenerator: OutputGenerator {
     }
     
     private func createAcknowledgementsPlist() throws {
-        let packageChildPanes: [Specifier] = packages.map { .childPane(title: $0.name, file: "Packages/\($0.name)") }
+        let packageChildPanes: [Specifier] = packages.map { .childPane(title: $0.nameWithVersion, file: "Packages/\($0.name)") }
         let preferenceSpecifiers: [Specifier] = [.group(title: "Licenses")] + packageChildPanes
         let acknowledgementsPlist = PropertyList(stringsTable: "Acknowledgements", preferenceSpecifiers: preferenceSpecifiers)
         let encodedAcknowledgements = try encoder.encode(acknowledgementsPlist)


### PR DESCRIPTION
This pull request introduces enhancements to the `SwiftPackageListPlugin` and `SwiftPackageList` components, focusing on configurability and improved output. The primary changes include adding support for a custom source packages path, a new computed property for package naming with versions, and updates to the acknowledgments output to include package versions.

### Enhancements to `SwiftPackageListPlugin`:

* Added a new optional property, `customSourcePackagesPath`, to the `Configuration` struct, allowing users to specify a custom path for source packages. (`Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Configuration.swift`, [Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Configuration.swiftR25](diffhunk://#diff-1efd1abb16965019e5d2c885e7db8e55814d4ba6f80318a5ea44b75415180fb0R25))
* Updated the `sourcePackagesDirectory` method to accept an optional `customSourcePackagesDirectory` parameter and include it in the search paths for source packages. (`Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift`, [[1]](diffhunk://#diff-ea3204b7c429652d225b954d5c734d53df7e59b04fb964fe8878134860c273deL19-R22) [[2]](diffhunk://#diff-ea3204b7c429652d225b954d5c734d53df7e59b04fb964fe8878134860c273deL55-R61) [[3]](diffhunk://#diff-ea3204b7c429652d225b954d5c734d53df7e59b04fb964fe8878134860c273deL69-R81)
* Updated the README to document the new `customSourcePackagesPath` configuration option. (`README.md`, [README.mdL88-R89](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R89))

### Improvements to package metadata:

* Introduced a new computed property, `nameWithVersion`, in the `Package` extension, which concatenates the package name with its version if available. (`Sources/SwiftPackageList/Package.swift`, [Sources/SwiftPackageList/Package.swiftR73-R78](diffhunk://#diff-ef3e3b6012a0b390d2f3c874207ecc04a2a20892ed6a629bfeed70bb18f0833cR73-R78))
* Updated the `SettingsBundleGenerator` to use `nameWithVersion` for child pane titles, ensuring package versions are included in the acknowledgments output. (`Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator.swift`, [Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator.swiftL53-R53](diffhunk://#diff-4cf9b011b48caaffbcda85f2a73b4618a3991068af004f59c71b25b29c55155aL53-R53))